### PR TITLE
adding standard node callback support

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -123,6 +123,20 @@ Promise.prototype.wait = function(){
   return exports.wait(this);
 };
 
+/**
+ * When promise is resolved or rejected, call a single callback in the style of Node callbacks
+ *
+ * @param {Function} nodeCallback		The callback function (e.g. function(err, result))
+ * @param {*=} opt_scope				Optional scope to set in the callback (default: null)
+ * @return {*}
+ */
+Promise.prototype.thenNode = function(nodeCallback, opt_scope) {
+	return this.then(
+		nodeCallback.bind(opt_scope ? opt_scope : null, null), // no err
+		nodeCallback.bind(opt_scope ? opt_scope : null) // err is first param
+	);
+};
+
 Deferred.prototype = Promise.prototype;
 // A deferred provides an API for creating and resolving a promise.
 exports.Promise = exports.Deferred = exports.defer = defer;

--- a/test-promise.js
+++ b/test-promise.js
@@ -2,7 +2,7 @@ sys = require("sys");
 var fs = require('./fs-promise');
 
 // open a file and read it
-fs.open("fs-promise.js", process.O_RDONLY).then(function(fd){
+fs.open("fs-promise.js", 'r').then(function(fd){
   return fs.read(fd, 4096);
 }).then(function(args){
   sys.puts(args[0]);
@@ -10,3 +10,21 @@ fs.open("fs-promise.js", process.O_RDONLY).then(function(fd){
 
 // does the same thing
 fs.readFile("fs-promise.js").addCallback(sys.puts);
+
+// does the same thing
+fs.readFile("fs-promise.js").thenNode(function(err, result) {
+	if (err) {
+		console.error(err);
+	} else {
+		console.info('thenNode result success');
+	}
+});
+
+// forced error
+fs.readFile("foobar.js").thenNode(function(err, result) {
+	if (err) {
+		console.info('thenNode err success');
+	} else {
+		console.error('err should be passed');
+	}
+});


### PR DESCRIPTION
adding method "thenNode" which takes a standard node callback (e.g. function(err, result))

Take a look and let me know what you think.
